### PR TITLE
Add GitHub API integration for scanning all repos

### DIFF
--- a/git_activity_dashboard/Cargo.lock
+++ b/git_activity_dashboard/Cargo.lock
@@ -56,7 +56,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -67,7 +67,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -86,6 +86,18 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -108,6 +120,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytes"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cast"
@@ -204,6 +222,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,10 +274,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -258,6 +338,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -278,7 +406,7 @@ version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232e6a7bfe35766bf715e55a88b39a700596c0ccfd88cd3680b4cdb40d66ef70"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -302,10 +430,12 @@ dependencies = [
  "once_cell",
  "phf",
  "regex",
+ "reqwest",
  "rustc-hash",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "tokio",
  "walkdir",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -325,10 +455,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -473,6 +699,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minicov"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,12 +839,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -620,6 +902,32 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -686,6 +994,18 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -771,10 +1091,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
 
 [[package]]
 name = "rustversion"
@@ -795,6 +1177,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -852,6 +1266,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,10 +1290,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -893,6 +1345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +1362,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +1404,86 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tokio"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2 0.6.1",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -958,6 +1530,21 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -1074,7 +1661,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1138,11 +1725,234 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/git_activity_dashboard/Cargo.toml
+++ b/git_activity_dashboard/Cargo.toml
@@ -47,6 +47,10 @@ git2 = "0.18"
 walkdir = "2.4"
 ignore = "0.4"  # gitignore pattern matching (same as ripgrep)
 
+# GitHub API integration
+reqwest = { version = "0.11", features = ["json", "blocking"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
+
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 

--- a/git_activity_dashboard/src/github.rs
+++ b/git_activity_dashboard/src/github.rs
@@ -1,0 +1,633 @@
+//! GitHub API integration for fetching and cloning user repositories
+//!
+//! This module provides functionality to:
+//! - List all repositories for an authenticated user or specific username
+//! - Clone repositories that don't exist locally
+//! - Skip already-cloned repositories for efficiency
+
+use git2::{Cred, FetchOptions, RemoteCallbacks};
+use reqwest::blocking::Client;
+use reqwest::header::{ACCEPT, AUTHORIZATION, USER_AGENT};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::path::{Path, PathBuf};
+
+/// GitHub repository metadata from the API
+#[derive(Debug, Deserialize, Clone)]
+pub struct GitHubRepo {
+    pub name: String,
+    pub full_name: String,
+    pub clone_url: String,
+    pub ssh_url: String,
+    pub private: bool,
+    pub fork: bool,
+    pub archived: bool,
+    pub size: u64,
+    #[serde(default)]
+    pub language: Option<String>,
+    pub default_branch: String,
+}
+
+/// Language statistics from GitHub API (bytes per language)
+pub type LanguageStats = std::collections::HashMap<String, u64>;
+
+/// File extension statistics (count and total size)
+pub type FileTypeStats = std::collections::HashMap<String, (u64, u64)>; // (count, bytes)
+
+/// Repository stats fetched from GitHub API (no cloning required)
+#[derive(Debug, Clone, Serialize)]
+pub struct GitHubRepoStats {
+    pub name: String,
+    pub full_name: String,
+    pub private: bool,
+    pub fork: bool,
+    pub archived: bool,
+    pub size_kb: u64,
+    pub primary_language: Option<String>,
+    /// Bytes of code per language
+    pub languages: LanguageStats,
+    /// File counts and sizes by extension
+    pub file_types: FileTypeStats,
+    /// Total file count
+    pub file_count: u64,
+    /// Estimated lines of code (rough calculation from bytes)
+    pub estimated_loc: u64,
+}
+
+/// Options for GitHub scanning
+#[derive(Debug, Clone)]
+pub struct GitHubScanOptions {
+    /// GitHub username to scan (if None, uses authenticated user)
+    pub username: Option<String>,
+    /// Directory to clone repos into
+    pub clone_dir: PathBuf,
+    /// Include forked repositories
+    pub include_forks: bool,
+    /// Include archived repositories
+    pub include_archived: bool,
+    /// Include private repositories (requires auth)
+    pub include_private: bool,
+    /// Skip cloning, only analyze existing repos
+    pub skip_clone: bool,
+}
+
+impl Default for GitHubScanOptions {
+    fn default() -> Self {
+        Self {
+            username: None,
+            clone_dir: PathBuf::from("./github_repos"),
+            include_forks: false,
+            include_archived: false,
+            include_private: true,
+            skip_clone: false,
+        }
+    }
+}
+
+/// Result of scanning GitHub repositories
+#[derive(Debug)]
+pub struct ScanResult {
+    /// Paths to repositories ready for analysis
+    pub repo_paths: Vec<PathBuf>,
+    /// Repositories that were newly cloned
+    pub cloned: Vec<String>,
+    /// Repositories that already existed locally
+    pub existing: Vec<String>,
+    /// Repositories that were skipped (forks, archived, etc.)
+    pub skipped: Vec<String>,
+    /// Repositories that failed to clone
+    pub failed: Vec<(String, String)>,
+}
+
+/// GitHub API client
+pub struct GitHubClient {
+    client: Client,
+    token: Option<String>,
+}
+
+impl GitHubClient {
+    /// Create a new GitHub client, optionally with authentication
+    pub fn new() -> Result<Self, String> {
+        let token = env::var("GITHUB_TOKEN").ok();
+
+        let client = Client::builder()
+            .build()
+            .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+        Ok(Self { client, token })
+    }
+
+    /// Create a client with an explicit token
+    pub fn with_token(token: String) -> Result<Self, String> {
+        let client = Client::builder()
+            .build()
+            .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+        Ok(Self {
+            client,
+            token: Some(token),
+        })
+    }
+
+    /// Check if authenticated
+    pub fn is_authenticated(&self) -> bool {
+        self.token.is_some()
+    }
+
+    /// Get the authenticated user's login name
+    pub fn get_authenticated_user(&self) -> Result<String, String> {
+        let token = self.token.as_ref().ok_or("No GitHub token configured")?;
+
+        let response = self
+            .client
+            .get("https://api.github.com/user")
+            .header(USER_AGENT, "git-activity-dashboard")
+            .header(ACCEPT, "application/vnd.github+json")
+            .header(AUTHORIZATION, format!("Bearer {}", token))
+            .send()
+            .map_err(|e| format!("Failed to fetch user: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(format!(
+                "GitHub API error: {} - {}",
+                response.status(),
+                response.text().unwrap_or_default()
+            ));
+        }
+
+        #[derive(Deserialize)]
+        struct User {
+            login: String,
+        }
+
+        let user: User = response
+            .json()
+            .map_err(|e| format!("Failed to parse user response: {}", e))?;
+
+        Ok(user.login)
+    }
+
+    /// Fetch all repositories for a user
+    pub fn list_repos(&self, username: Option<&str>) -> Result<Vec<GitHubRepo>, String> {
+        let mut all_repos = Vec::new();
+        let mut page = 1;
+        let per_page = 100;
+
+        loop {
+            let url = if let Some(user) = username {
+                format!(
+                    "https://api.github.com/users/{}/repos?per_page={}&page={}&sort=updated",
+                    user, per_page, page
+                )
+            } else {
+                // Authenticated user's repos (includes private)
+                format!(
+                    "https://api.github.com/user/repos?per_page={}&page={}&sort=updated&affiliation=owner",
+                    per_page, page
+                )
+            };
+
+            let mut request = self
+                .client
+                .get(&url)
+                .header(USER_AGENT, "git-activity-dashboard")
+                .header(ACCEPT, "application/vnd.github+json");
+
+            if let Some(token) = &self.token {
+                request = request.header(AUTHORIZATION, format!("Bearer {}", token));
+            }
+
+            let response = request
+                .send()
+                .map_err(|e| format!("Failed to fetch repos: {}", e))?;
+
+            if !response.status().is_success() {
+                return Err(format!(
+                    "GitHub API error: {} - {}",
+                    response.status(),
+                    response.text().unwrap_or_default()
+                ));
+            }
+
+            let repos: Vec<GitHubRepo> = response
+                .json()
+                .map_err(|e| format!("Failed to parse repos: {}", e))?;
+
+            if repos.is_empty() {
+                break;
+            }
+
+            all_repos.extend(repos);
+            page += 1;
+
+            // Safety limit
+            if page > 50 {
+                break;
+            }
+        }
+
+        Ok(all_repos)
+    }
+
+    /// Fetch the file tree for a repository to get file type statistics
+    pub fn get_repo_tree(&self, owner: &str, repo: &str, branch: &str) -> Result<FileTypeStats, String> {
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/git/trees/{}?recursive=1",
+            owner, repo, branch
+        );
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header(USER_AGENT, "git-activity-dashboard")
+            .header(ACCEPT, "application/vnd.github+json");
+
+        if let Some(token) = &self.token {
+            request = request.header(AUTHORIZATION, format!("Bearer {}", token));
+        }
+
+        let response = request
+            .send()
+            .map_err(|e| format!("Failed to fetch tree: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(format!(
+                "GitHub API error: {} - {}",
+                response.status(),
+                response.text().unwrap_or_default()
+            ));
+        }
+
+        #[derive(Deserialize)]
+        struct TreeItem {
+            path: String,
+            #[serde(rename = "type")]
+            item_type: String,
+            #[serde(default)]
+            size: Option<u64>,
+        }
+
+        #[derive(Deserialize)]
+        struct TreeResponse {
+            tree: Vec<TreeItem>,
+            #[allow(dead_code)]
+            truncated: bool,
+        }
+
+        let tree_response: TreeResponse = response
+            .json()
+            .map_err(|e| format!("Failed to parse tree: {}", e))?;
+
+        let mut file_types: FileTypeStats = std::collections::HashMap::new();
+
+        for item in tree_response.tree {
+            if item.item_type != "blob" {
+                continue; // Skip directories
+            }
+
+            // Extract file extension
+            let ext = item
+                .path
+                .rsplit('.')
+                .next()
+                .map(|e| e.to_lowercase())
+                .unwrap_or_else(|| "no_extension".to_string());
+
+            // Skip if the extension is the full filename (no actual extension)
+            let ext = if ext == item.path.to_lowercase() {
+                "no_extension".to_string()
+            } else {
+                ext
+            };
+
+            let size = item.size.unwrap_or(0);
+            let entry = file_types.entry(ext).or_insert((0, 0));
+            entry.0 += 1; // count
+            entry.1 += size; // bytes
+        }
+
+        Ok(file_types)
+    }
+
+    /// Fetch language statistics for a repository (no cloning required)
+    pub fn get_repo_languages(&self, owner: &str, repo: &str) -> Result<LanguageStats, String> {
+        let url = format!("https://api.github.com/repos/{}/{}/languages", owner, repo);
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header(USER_AGENT, "git-activity-dashboard")
+            .header(ACCEPT, "application/vnd.github+json");
+
+        if let Some(token) = &self.token {
+            request = request.header(AUTHORIZATION, format!("Bearer {}", token));
+        }
+
+        let response = request
+            .send()
+            .map_err(|e| format!("Failed to fetch languages: {}", e))?;
+
+        if !response.status().is_success() {
+            return Err(format!(
+                "GitHub API error: {} - {}",
+                response.status(),
+                response.text().unwrap_or_default()
+            ));
+        }
+
+        response
+            .json()
+            .map_err(|e| format!("Failed to parse languages: {}", e))
+    }
+
+    /// Get stats for all repos without cloning (API only)
+    pub fn get_all_repo_stats(&self, username: Option<&str>, options: &GitHubScanOptions) -> Result<Vec<GitHubRepoStats>, String> {
+        let username = if let Some(user) = username {
+            user.to_string()
+        } else if let Some(ref user) = options.username {
+            user.clone()
+        } else {
+            self.get_authenticated_user()?
+        };
+
+        println!("Fetching repository statistics for: {}", username);
+
+        let repos = self.list_repos(Some(&username))?;
+        println!("Found {} repositories, fetching stats...\n", repos.len());
+
+        let mut stats = Vec::new();
+
+        for repo in repos {
+            // Filter based on options
+            if repo.fork && !options.include_forks {
+                continue;
+            }
+            if repo.archived && !options.include_archived {
+                continue;
+            }
+            if repo.private && !options.include_private {
+                continue;
+            }
+
+            print!("  {} ", repo.name);
+
+            // Fetch languages
+            let languages = match self.get_repo_languages(&username, &repo.name) {
+                Ok(langs) => langs,
+                Err(_) => std::collections::HashMap::new(),
+            };
+
+            // Fetch file tree for file type stats
+            let (file_types, file_count) = match self.get_repo_tree(&username, &repo.name, &repo.default_branch) {
+                Ok(types) => {
+                    let count: u64 = types.values().map(|(c, _)| c).sum();
+                    (types, count)
+                }
+                Err(_) => (std::collections::HashMap::new(), 0),
+            };
+
+            let total_bytes: u64 = languages.values().sum();
+            let estimated_loc = total_bytes / 40;
+
+            println!("- {} files, {} LOC", file_count, estimated_loc);
+
+            stats.push(GitHubRepoStats {
+                name: repo.name,
+                full_name: repo.full_name,
+                private: repo.private,
+                fork: repo.fork,
+                archived: repo.archived,
+                size_kb: repo.size,
+                primary_language: repo.language,
+                languages,
+                file_types,
+                file_count,
+                estimated_loc,
+            });
+        }
+
+        Ok(stats)
+    }
+
+    /// Print a summary of GitHub stats (no cloning)
+    pub fn print_stats_summary(stats: &[GitHubRepoStats]) {
+        use std::collections::HashMap;
+
+        let mut total_bytes: u64 = 0;
+        let mut total_loc: u64 = 0;
+        let mut total_files: u64 = 0;
+        let mut language_totals: HashMap<String, u64> = HashMap::new();
+        let mut file_type_totals: HashMap<String, (u64, u64)> = HashMap::new(); // (count, bytes)
+
+        for repo in stats {
+            total_loc += repo.estimated_loc;
+            total_files += repo.file_count;
+
+            for (lang, bytes) in &repo.languages {
+                total_bytes += bytes;
+                *language_totals.entry(lang.clone()).or_insert(0) += bytes;
+            }
+
+            for (ext, (count, bytes)) in &repo.file_types {
+                let entry = file_type_totals.entry(ext.clone()).or_insert((0, 0));
+                entry.0 += count;
+                entry.1 += bytes;
+            }
+        }
+
+        println!("\n{}", "=".repeat(60));
+        println!("GITHUB REPOSITORY STATISTICS");
+        println!("{}", "=".repeat(60));
+
+        println!("\nRepositories analyzed: {}", stats.len());
+        println!("Total files: {}", total_files);
+        println!("Total code size: {:.2} MB", total_bytes as f64 / 1_000_000.0);
+        println!("Estimated lines of code: {}", total_loc);
+
+        // Sort languages by bytes
+        let mut sorted_langs: Vec<_> = language_totals.into_iter().collect();
+        sorted_langs.sort_by(|a, b| b.1.cmp(&a.1));
+
+        println!("\n{}", "-".repeat(40));
+        println!("LANGUAGES BY SIZE");
+        println!("{}", "-".repeat(40));
+
+        for (lang, bytes) in sorted_langs.iter().take(15) {
+            let pct = if total_bytes > 0 { (*bytes as f64 / total_bytes as f64) * 100.0 } else { 0.0 };
+            let bar = "█".repeat((pct / 2.0) as usize);
+            let loc = bytes / 40; // Rough estimate
+            println!("  {:20} {:5.1}%  ~{:>8} LOC  {}", lang, pct, loc, bar);
+        }
+
+        // File types by count
+        let mut sorted_file_types: Vec<_> = file_type_totals.into_iter().collect();
+        sorted_file_types.sort_by(|a, b| b.1.0.cmp(&a.1.0)); // Sort by count
+
+        println!("\n{}", "-".repeat(40));
+        println!("FILE TYPES (by extension)");
+        println!("{}", "-".repeat(40));
+
+        for (ext, (count, bytes)) in sorted_file_types.iter().take(20) {
+            let pct = if total_files > 0 { (*count as f64 / total_files as f64) * 100.0 } else { 0.0 };
+            let bar = "█".repeat((pct / 2.0) as usize);
+            let kb = bytes / 1024;
+            println!("  .{:19} {:5} files {:5.1}%  {:>6} KB  {}", ext, count, pct, kb, bar);
+        }
+
+        println!("\n{}", "-".repeat(40));
+        println!("REPOSITORIES");
+        println!("{}", "-".repeat(40));
+
+        // Sort repos by estimated LOC
+        let mut sorted_repos: Vec<_> = stats.iter().collect();
+        sorted_repos.sort_by(|a, b| b.estimated_loc.cmp(&a.estimated_loc));
+
+        for repo in sorted_repos.iter().take(15) {
+            let lang = repo.primary_language.as_deref().unwrap_or("Unknown");
+            let private_badge = if repo.private { "[private]" } else { "" };
+            println!(
+                "  {:30} {:>6} files {:>8} LOC  {:15} {}",
+                repo.name, repo.file_count, repo.estimated_loc, lang, private_badge
+            );
+        }
+
+        println!("\n{}\n", "=".repeat(60));
+    }
+
+    /// Clone a repository to the specified directory
+    fn clone_repo(&self, repo: &GitHubRepo, target_dir: &Path) -> Result<PathBuf, String> {
+        let repo_path = target_dir.join(&repo.name);
+
+        // Check if already exists
+        if repo_path.exists() && repo_path.join(".git").exists() {
+            return Ok(repo_path);
+        }
+
+        // Create parent directory if needed
+        if !target_dir.exists() {
+            std::fs::create_dir_all(target_dir)
+                .map_err(|e| format!("Failed to create directory: {}", e))?;
+        }
+
+        // Set up authentication callbacks for private repos
+        let mut callbacks = RemoteCallbacks::new();
+
+        if let Some(token) = &self.token {
+            let token = token.clone();
+            callbacks.credentials(move |_url, _username_from_url, _allowed_types| {
+                Cred::userpass_plaintext("x-access-token", &token)
+            });
+        }
+
+        let mut fetch_options = FetchOptions::new();
+        fetch_options.remote_callbacks(callbacks);
+
+        let mut builder = git2::build::RepoBuilder::new();
+        builder.fetch_options(fetch_options);
+
+        // Clone using HTTPS (works with token auth)
+        builder
+            .clone(&repo.clone_url, &repo_path)
+            .map_err(|e| format!("Failed to clone {}: {}", repo.name, e))?;
+
+        Ok(repo_path)
+    }
+
+    /// Scan and optionally clone all repositories for a user
+    pub fn scan_repos(&self, options: &GitHubScanOptions) -> Result<ScanResult, String> {
+        let username = if let Some(ref user) = options.username {
+            user.clone()
+        } else {
+            self.get_authenticated_user()?
+        };
+
+        println!("Fetching repositories for: {}", username);
+
+        let repos = self.list_repos(Some(&username))?;
+        println!("Found {} repositories", repos.len());
+
+        let mut result = ScanResult {
+            repo_paths: Vec::new(),
+            cloned: Vec::new(),
+            existing: Vec::new(),
+            skipped: Vec::new(),
+            failed: Vec::new(),
+        };
+
+        // Create clone directory
+        if !options.skip_clone && !options.clone_dir.exists() {
+            std::fs::create_dir_all(&options.clone_dir)
+                .map_err(|e| format!("Failed to create clone directory: {}", e))?;
+        }
+
+        for repo in repos {
+            // Filter based on options
+            if repo.fork && !options.include_forks {
+                result.skipped.push(format!("{} (fork)", repo.name));
+                continue;
+            }
+
+            if repo.archived && !options.include_archived {
+                result.skipped.push(format!("{} (archived)", repo.name));
+                continue;
+            }
+
+            if repo.private && !options.include_private {
+                result.skipped.push(format!("{} (private)", repo.name));
+                continue;
+            }
+
+            let repo_path = options.clone_dir.join(&repo.name);
+
+            // Check if repo already exists locally
+            if repo_path.exists() && repo_path.join(".git").exists() {
+                println!("  [exists] {}", repo.name);
+                result.existing.push(repo.name.clone());
+                result.repo_paths.push(repo_path);
+                continue;
+            }
+
+            // Skip cloning if requested
+            if options.skip_clone {
+                result.skipped.push(format!("{} (not cloned locally)", repo.name));
+                continue;
+            }
+
+            // Clone the repository
+            print!("  [cloning] {}... ", repo.name);
+            match self.clone_repo(&repo, &options.clone_dir) {
+                Ok(path) => {
+                    println!("done");
+                    result.cloned.push(repo.name.clone());
+                    result.repo_paths.push(path);
+                }
+                Err(e) => {
+                    println!("failed");
+                    result.failed.push((repo.name.clone(), e));
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_github_client_creation() {
+        // Should not panic even without token
+        let client = GitHubClient::new();
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_scan_options_default() {
+        let options = GitHubScanOptions::default();
+        assert!(!options.include_forks);
+        assert!(!options.include_archived);
+        assert!(options.include_private);
+    }
+}

--- a/git_activity_dashboard/src/lib.rs
+++ b/git_activity_dashboard/src/lib.rs
@@ -29,7 +29,10 @@ pub use utils::{format_number, contribution_type_label, sort_by_value, calculate
 pub use git::{analyze_repo, find_repos, is_git_repo, get_head_hash, AnalyzeOptions, GitError};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use github::{GitHubClient, GitHubRepo, GitHubScanOptions, GitHubRepoStats, ScanResult};
+pub use github::{
+    GitHubClient, GitHubRepo, GitHubScanOptions, GitHubRepoStats, ScanResult,
+    parse_date, get_month_range, get_last_month_range,
+};
 
 // WASM bindings
 #[cfg(feature = "wasm")]

--- a/git_activity_dashboard/src/lib.rs
+++ b/git_activity_dashboard/src/lib.rs
@@ -10,6 +10,10 @@ pub mod utils;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod git;
 
+// GitHub API integration (not available in WASM)
+#[cfg(not(target_arch = "wasm32"))]
+pub mod github;
+
 pub use analyzer::{
     GitAnalyzer, RepoStats, CommitInfo, TotalStats, DashboardData, ActivitySummary,
     ParseOptions, ParseError, GIT_LOG_FORMAT, GIT_LOG_DELIMITER, git_log_command,
@@ -23,6 +27,9 @@ pub use utils::{format_number, contribution_type_label, sort_by_value, calculate
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use git::{analyze_repo, find_repos, is_git_repo, get_head_hash, AnalyzeOptions, GitError};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use github::{GitHubClient, GitHubRepo, GitHubScanOptions, GitHubRepoStats, ScanResult};
 
 // WASM bindings
 #[cfg(feature = "wasm")]


### PR DESCRIPTION
Features:
- `--github-stats [USERNAME]`: Fetch stats via API only (no cloning)
  - Lists all repos with language breakdown
  - Shows file types by extension with counts
  - Displays estimated LOC per language
- `--github-scan [USERNAME]`: Clone repos and run full analysis
  - Skips already-cloned repos
  - Supports private repos with GITHUB_TOKEN
- `--include-forks` and `--include-archived` filters
- `--github-clone-dir` to specify clone destination

Uses GitHub API endpoints:
- /user/repos for listing
- /repos/{owner}/{repo}/languages for language stats
- /repos/{owner}/{repo}/git/trees for file type breakdown